### PR TITLE
ci: use only major versions in image tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,10 +47,10 @@ jobs:
           export NODE_BASED_IMAGE_NAME=$(cat .node-based-image-name)
           export RAW_NODE_VERSION=$(docker run --rm -t \
             $NODE_BASED_IMAGE_NAME node --version)
-          export NODE_VERSION=$(echo $RAW_NODE_VERSION | sed 's/^.//')
+          export NODE_VERSION=$(echo $RAW_NODE_VERSION | sed 's/^.//' | cut -d '.' -f 1)
           export CHROMIUM_VERSION=$(docker run --rm -t \
             $NODE_BASED_IMAGE_NAME /usr/bin/chromium-browser --version \
-            | cut -d ' ' -f 2)
+            | cut -d ' ' -f 2 | cut -d '.' -f 1)
           docker tag $NODE_BASED_IMAGE_NAME \
             $IMAGE_NAME:node${NODE_VERSION::-1}-chromium${CHROMIUM_VERSION}
           [[ $(cat .existing-image-hash) != $(cat .new-image-hash) ]] \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Multi-stage build to separate development dependencies from
 production:
 
 ```Dockerfile
-FROM node:13-alpine
+FROM node:12-alpine
 
 WORKDIR /usr/src/app-deps
 
@@ -61,7 +61,7 @@ COPY . .
 RUN npm run --quiet compile-my-code && \
   npm prune --quiet --production
 
-FROM shivjm/node-chromium-alpine:13
+FROM shivjm/node-chromium-alpine:12
 
 USER node
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ https://github.com/shivjm/docker-node-chromium-alpine/issues/
 
 ## Tags
 
-See all tags at [Docker Hub
-(shivjm/node-chromium-alpine)](https://hub.docker.com/repository/docker/shivjm/node-chromium-alpine).
+<code>node<var>N</var>-chromium<var>C</var></code>, where <var>N</var> is the Node.js major version number (8, 10, 12, or 14) and <var>C</var> is the Chromium major version number. For example, to use Node.js 14 with Chromium 81, use the `shivjm/node-chromium-alpine:node14-chromium81` image. No `latest` image is provided.
+
+See all available tags at [Docker Hub (shivjm/node-chromium-alpine)](https://hub.docker.com/repository/docker/shivjm/node-chromium-alpine).
+
+## Versioning
+
+The newest version of Chromium provided by Alpine Linux is used.
+
+The version of Alpine Linux depends on [the upstream <code>node:<var>N</var>-alpine</code> image](https://hub.docker.com/_/node?tab=tags&page=1&ordering=last_updated&name=alpine).
 
 ## Example Dockerfiles
 
@@ -74,7 +81,7 @@ ENTRYPOINT ["npm", "start", "--quiet"]
 ## Puppeteer
 
 When you install Puppeteer, it also downloads a known version of
-Chromium to store under `node_modules`, and defaults to using that
+Chromium to store under node_modules, and defaults to using that
 binary. You can skip this download using the environment variable
 `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`. You’ll also need to set
 `PUPPETEER_EXECUTABLE_PATH` to the installed Chromium. A partial


### PR DESCRIPTION
Instead of `node12.22.0-chromium81.0.4044.113`, the tag should be `node12-chromium81`.