### PR TITLE
build tags for node 18 and node 19

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [8, 10, 12, 13, 14, 15, 16, 17]
+        node: [8, 10, 12, 13, 14, 15, 16, 17, 18, 19]
     steps:
       - uses: actions/checkout@v2
       - name: Pull existing version


### PR DESCRIPTION
In the meantime node 18 is LTS and node 19 is the dev version, and their node:x-alpine dockerImages exist:

- [node:18-alpine](https://hub.docker.com/layers/library/node/18-alpine/images/sha256-2322b1bb3917b313f2e9308395aa5c39d51b91cc92a5d4d5be6d0451fcfb4d24)
- [node:19-alpine](https://hub.docker.com/layers/library/node/19-alpine/images/sha256-ebd018afea26341e981ce1b01d6859a5d185b2d840f89c075239e3b7e6e92715?context=explore)

This PR adapts your publish.yml to build tags of node-chromium-alpine for these version as well.

(I was thinking about removing node versions out of maintenance, i.e. 8, 10, 12, and 13, but for the moment decided against it.)